### PR TITLE
Fix rounding error in test indices

### DIFF
--- a/trainer.lua
+++ b/trainer.lua
@@ -100,7 +100,7 @@ function trainer.test(dataset)
   local all = 0
 
   -- generate indices and split them into batches
-  local indices = torch.linspace(1,nbr_samples,nbr_samples):long()
+  local indices = torch.range(1,nbr_samples):long()
   indices = indices:split(trainer.batch_size)
 
   -- preallocate input and target tensors


### PR DESCRIPTION
torch.linspace is not suited to generate indices. Rounding errors in torch.linspace generate bad indices before the model evaluation on the testset. This pull request solve the problem using the new function torch.range.

Here is a bunch of code to explain the problem.

``` lua
local nbr_samples = 12630 -- testset size
local batch_size = 50

local indices_float = torch.linspace(torch.FloatTensor(nbr_samples),
                                     1,
                                     nbr_samples,
                                     nbr_samples)
indices_float = indices_float:long()
indices_float = indices_float:split(batch_size)

local indices_double = torch.linspace(torch.DoubleTensor(nbr_samples),
                                      1,
                                      nbr_samples,
                                      nbr_samples)
indices_double = indices_double:long()
indices_double = indices_double:split(batch_size)

print('Normal', indices_float[1][1], indices_double[1][1])
print('Normal', indices_float[2][1], indices_double[2][1])

for i=1, #indices_float do
   if indices_float[i][1] ~= indices_double[i][1] then
      print('Error', indices_float[i][1], indices_double[i][1])
   end
end
```

```
> Normal    1   1   
Normal  51  51  
Error   2850    2851    
Error   3050    3051    
Error   3250    3251    
Error   3450    3451    
Error   3650    3651    
Error   3850    3851    
Error   4050    4051    
Error   5700    5701    
Error   6100    6101    
Error   6500    6501    
Error   6900    6901    
Error   7300    7301    
Error   7700    7701    
Error   8100    8101    
Error   11400   11401   
Error   12200   12201   
```
