### PR TITLE
Add missing require in eval mode for stn

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -78,6 +78,9 @@ local network
 if opt.eval then
   if opt.output then
     print('Loading network from '..opt.output)
+    if opt.st then
+      require 'stn'
+    end
     network = torch.load(opt.output)
   else
     error('Must supply the network to use in eval mode')


### PR DESCRIPTION
Fix #8

The only drawback is that when using the `--eval` mode with a network containing a Spatial Transformer, the `--st` must also be specified otherwise the network will not be loaded properly. This could be prevented by doing a `pcall` on the `torch.load` and retry it after requirering `stn` but it does not feel like the right thing to do.
